### PR TITLE
Implemented ansible-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ script:
   - container_id=$(mktemp)
   - role_name="replace_role"
   - 'sudo docker run --detach --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --volume="${PWD}":/etc/ansible/roles/${role_name}:ro ${distribution}-${version}:ansible ${init} > "${container_id}"'
+  - 'sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-lint -c /.ansible-lint /etc/ansible/roles/${role_name}/tests/test.yml'
   - 'sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/${role_name}/tests/test.yml --syntax-check'
   - 'sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/${role_name}/tests/test.yml'
   - >

--- a/README.md
+++ b/README.md
@@ -33,13 +33,26 @@ In regards to using these tests within a new or existing Ansible role you may
 do the following in order to integrate these tests.
 
 ```bash
-wget https://github.com/mrlesmithjr/travis-ansible-testing/archive/v1.3.tar.gz
-tar zxvf v1.3.tar.gz --strip 1 --exclude="README.md"
+wget https://github.com/mrlesmithjr/travis-ansible-testing/archive/v1.4.tar.gz
+tar zxvf v1.4.tar.gz --strip 1 --exclude="README.md"
 ./setup_travis_tests.sh
 ```
 
 > NOTE: You must also setup Travis integration for the repo you would like to
 > integrate with.
+
+## ansible-lint
+
+We have implemented [`ansible-lint`](https://github.com/willthames/ansible-lint)
+as part of these tests.
+
+> NOTE: ansible-lint checks playbooks for practices and behaviour that could potentially be improved
+
+If `ansible-lint` detects something the testing will fail. So you need to ensure
+that your code aligns to `ansible-lint` practices. There are a few ways that you
+can resolve these issues if the code being detected is determined to be accurate.
+Use the [following](https://github.com/willthames/ansible-lint#false-positives) as
+how to resolve these alerts.
 
 ## License
 

--- a/setup_travis_tests.sh
+++ b/setup_travis_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAR_FILE="v1.3.tar.gz"
+TAR_FILE="v1.4.tar.gz"
 
 # Prompt for Ansible role name
 read -p "Enter the Ansible role name: " input

--- a/tests/.ansible-lint
+++ b/tests/.ansible-lint
@@ -1,0 +1,1 @@
+skip_list: []

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -17,7 +17,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == system
     rm -f /lib/systemd/system/basic.target.wants/*;\
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
-RUN pip install ansible
+RUN pip install ansible ansible-lint
 
 VOLUME ["/sys/fs/cgroup"]
 

--- a/tests/Dockerfile.debian-jessie
+++ b/tests/Dockerfile.debian-jessie
@@ -5,4 +5,4 @@ RUN apt-get update && \
     libssl-dev python-dev python-minimal python-pip python-setuptools \
     python-virtualenv
 
-RUN pip install --upgrade setuptools wheel && pip install ansible
+RUN pip install --upgrade setuptools wheel && pip install ansible ansible-lint

--- a/tests/Dockerfile.debian-stretch
+++ b/tests/Dockerfile.debian-stretch
@@ -5,4 +5,4 @@ RUN apt-get update && \
     libssl-dev python-dev python-minimal python-pip python-setuptools \
     python-virtualenv systemd
 
-RUN pip install --upgrade setuptools wheel && pip install ansible
+RUN pip install --upgrade setuptools wheel && pip install ansible ansible-lint

--- a/tests/Dockerfile.fedora-24
+++ b/tests/Dockerfile.fedora-24
@@ -16,7 +16,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == system
     rm -f /lib/systemd/system/basic.target.wants/*;\
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
-RUN pip install ansible
+RUN pip install ansible ansible-lint
 
 VOLUME ["/sys/fs/cgroup"]
 

--- a/tests/Dockerfile.fedora-25
+++ b/tests/Dockerfile.fedora-25
@@ -16,7 +16,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == system
     rm -f /lib/systemd/system/basic.target.wants/*;\
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
-RUN pip install ansible
+RUN pip install ansible ansible-lint
 
 VOLUME ["/sys/fs/cgroup"]
 

--- a/tests/Dockerfile.fedora-26
+++ b/tests/Dockerfile.fedora-26
@@ -16,7 +16,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == system
     rm -f /lib/systemd/system/basic.target.wants/*;\
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
-RUN pip install ansible
+RUN pip install ansible ansible-lint
 
 VOLUME ["/sys/fs/cgroup"]
 

--- a/tests/Dockerfile.ubuntu-bionic
+++ b/tests/Dockerfile.ubuntu-bionic
@@ -5,4 +5,4 @@ RUN apt-get update && \
     libssl-dev python-dev python-minimal python-pip python-setuptools \
     python-virtualenv systemd
 
-RUN pip install ansible
+RUN pip install ansible ansible-lint

--- a/tests/Dockerfile.ubuntu-trusty
+++ b/tests/Dockerfile.ubuntu-trusty
@@ -5,4 +5,4 @@ RUN apt-get update && \
     libssl-dev python-dev python-minimal python-pip python-setuptools \
     python-virtualenv
 
-RUN pip install --upgrade pip setuptools && pip install ansible
+RUN pip install --upgrade pip setuptools && pip install ansible ansible-lint

--- a/tests/Dockerfile.ubuntu-xenial
+++ b/tests/Dockerfile.ubuntu-xenial
@@ -5,4 +5,6 @@ RUN apt-get update && \
     libssl-dev python-dev python-minimal python-pip python-setuptools \
     python-virtualenv
 
-RUN pip install ansible
+RUN pip install ansible ansible-lint
+
+COPY .ansible-lint /


### PR DESCRIPTION
This resolves #1
By implementing ansible-lint, we can ensure that the playbooks/roles
follow best practices as part of the Travis-CI testing.